### PR TITLE
Avoid crash of demo2 when weblogo is not available

### DIFF
--- a/run_demo2.sh
+++ b/run_demo2.sh
@@ -88,13 +88,13 @@ echo "#------------------------------------------------------------------------#
 echo  -e "\n"
 echo "../PBstat.py -f psi_md_traj.PB.count -o psi_md_traj --map --neq --logo"
 pause
-../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo
+../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo || echo 'The command failed, is weblogo installed?'
 
 echo  -e "\n"
 echo "Define a residue frame (--residue-min and --residue-max options)"
 echo "../PBstat.py -f psi_md_traj.PB.count -o psi_md_traj --map --neq --logo --residue-min 10 --residue-max 30"
 pause
-../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo --residue-min 10 --residue-max 30
+../PBstat.py -f psi_md_traj_all.PB.count -o psi_md_traj --map --neq --logo --residue-min 10 --residue-max 30 || echo 'The command failed, is weblogo installed?'
 
 
 echo  -e "\n"


### PR DESCRIPTION
If weblogo is not available, then PBstat exits with a non 0 code.
Because run_demo2.sh has `set -e`, it exits when it encounter the non 0
code of PBstat. Therefore, the demo do not run until the end.

This commit display a message if weblogo is not installed, and allow the
demo to continue.
